### PR TITLE
Add split methods to data streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ where
 
 impl<V, KS, K> KeyedDataStream<V, KS, K>
 where
-    V: Clone + Send + Sync + 'static,
+    V: Send + Sync + 'static,
     KS: Fn(&Event<V>) -> K + Send + 'static,
     K: Hash + Eq + Send + Clone + 'static,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1267,16 +1267,13 @@ mod tests {
     async fn windowed_process_joined_events() {
         let env = Environment::default();
 
-        let source = SliceEventSource(
-            [
-                new_event(0_usize, 12, 10),
-                new_event(0_usize, 12, 12),
-                new_event(1_usize, 12, 30),
-            ]
-            .into(),
-        );
+        let source = SliceEventSource([
+            new_event(0_usize, 12, 10),
+            new_event(0_usize, 12, 12),
+            new_event(1_usize, 12, 30),
+        ]);
 
-        let sink = SliceEventAssertSink([new_event(vec![0_usize, 0_usize], 12, 10)].into());
+        let sink = SliceEventAssertSink([new_event(vec![0_usize, 0_usize], 12, 10)]);
 
         let stream = env.add_source(source);
 
@@ -1307,26 +1304,20 @@ mod tests {
     async fn windowed_process_state_separate_events() {
         let env = Environment::default();
 
-        let source = SliceEventSource(
-            [
-                new_event(0_usize, 12, 10),
-                new_event(0_usize, 12, 30),
-                new_event(0_usize, 12, 40),
-                new_event(1_usize, 12, 55),
-                new_event(1_usize, 12, 56),
-                new_event(2_usize, 13, 20),
-            ]
-            .into(),
-        );
+        let source = SliceEventSource([
+            new_event(0_usize, 12, 10),
+            new_event(0_usize, 12, 30),
+            new_event(0_usize, 12, 40),
+            new_event(1_usize, 12, 55),
+            new_event(1_usize, 12, 56),
+            new_event(2_usize, 13, 20),
+        ]);
 
-        let sink = SliceEventAssertSink(
-            [
-                new_event((0, 0, 0), 12, 10),
-                new_event((1, 1, 0), 12, 30),
-                new_event((2, 0, 1), 12, 55),
-            ]
-            .into(),
-        );
+        let sink = SliceEventAssertSink([
+            new_event((0, 0, 0), 12, 10),
+            new_event((1, 1, 0), 12, 30),
+            new_event((2, 0, 1), 12, 55),
+        ]);
 
         let stream = env.add_source(source);
 
@@ -1367,20 +1358,16 @@ mod tests {
     async fn windowed_process_state_joined_events() {
         let env = Environment::default();
 
-        let source = SliceEventSource(
-            [
-                new_event(0_usize, 12, 10),
-                new_event(0_usize, 12, 12),
-                new_event(0_usize, 12, 13),
-                new_event(1_usize, 12, 41),
-                new_event(1_usize, 12, 42),
-                new_event(2_usize, 12, 53),
-            ]
-            .into(),
-        );
+        let source = SliceEventSource([
+            new_event(0_usize, 12, 10),
+            new_event(0_usize, 12, 12),
+            new_event(0_usize, 12, 13),
+            new_event(1_usize, 12, 41),
+            new_event(1_usize, 12, 42),
+            new_event(2_usize, 12, 53),
+        ]);
 
-        let sink =
-            SliceEventAssertSink([new_event((0, 0), 12, 10), new_event((1, 0), 12, 41)].into());
+        let sink = SliceEventAssertSink([new_event((0, 0), 12, 10), new_event((1, 0), 12, 41)]);
 
         let stream = env.add_source(source);
 
@@ -1440,16 +1427,13 @@ mod tests {
     async fn windowed_aggregate_joined_events() {
         let env = Environment::default();
 
-        let source = SliceEventSource(
-            [
-                new_event(0_usize, 12, 10),
-                new_event(0_usize, 12, 12),
-                new_event(1_usize, 12, 30),
-            ]
-            .into(),
-        );
+        let source = SliceEventSource([
+            new_event(0_usize, 12, 10),
+            new_event(0_usize, 12, 12),
+            new_event(1_usize, 12, 30),
+        ]);
 
-        let sink = SliceEventAssertSink([new_event(4_usize, 12, 12)].into());
+        let sink = SliceEventAssertSink([new_event(4_usize, 12, 12)]);
 
         let stream = env.add_source(source);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,6 @@ where
 pub struct KeyedDataStream<V, KS, K>
 where
     KS: Fn(&Event<V>) -> K,
-    K: Hash + Eq + Send + Clone + 'static,
 {
     data_stream: DataStream<V>,
     selector: KS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,13 +221,11 @@ where
         self.nodes.borrow_mut().spawn(async move {
             let mut receiver = self.receiver;
             while let Some(event) = receiver.recv().await {
-                let left_sender = left_sender.clone();
                 let left_event = event.clone();
-                let left_join_handle =
-                    tokio::spawn(async move { left_sender.send(left_event).await });
-                let right_sender = right_sender.clone();
-                let right_join_handle = tokio::spawn(async move { right_sender.send(event).await });
-                let (left_result, right_result) = join!(left_join_handle, right_join_handle);
+                let right_event = event;
+
+                let (left_result, right_result) =
+                    join!(left_sender.send(left_event), right_sender.send(right_event));
 
                 if left_result.is_err() || right_result.is_err() {
                     return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1632,7 +1632,6 @@ mod tests {
             ));
 
         let (left_stream, right_stream) = stream.split();
-        //let left_stream = stream;
 
         let left_sink = SliceEventAssertSink([new_event(2, 12, 12)]);
 


### PR DESCRIPTION
This adds the `split` method to:

`DataStream`
`KeyedDataStream`
`WindowedDataStream`